### PR TITLE
Add support for 'actionable' Git status

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -165,6 +165,8 @@ SPACESHIP_GIT_ORDER=(
 )
 ```
 
+The other Git subsection shipped with Spaceship is `status_actionable`, a Git status where icons show changes that are not in the index yet. Described in [PR #359](https://git.io/vACxq)
+
 #### Git branch (`git_branch`)
 
 | Variable | Default | Meaning |

--- a/sections/git_status_actionable.zsh
+++ b/sections/git_status_actionable.zsh
@@ -1,0 +1,91 @@
+#
+# Actionable Git status
+#
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/git_status_options.zsh"
+
+# ------------------------------------------------------------------------------
+# Section
+# ------------------------------------------------------------------------------
+
+# A Git status where icons show changes that are not in the index yet.
+# This way, your icons are like a TODO list, "your job" (kinda) is to replace
+# all of the icons with + and then commit.
+# See PR #359 at https://git.io/vACxq
+# See git help status to know more about status formats
+spaceship_git_status_actionable() {
+  [[ $SPACESHIP_GIT_STATUS_SHOW == false ]] && return
+
+  spaceship::is_git || return
+
+  local INDEX git_status=""
+
+  INDEX=$(command git status --porcelain -b 2> /dev/null)
+
+  # Check for untracked files
+  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
+  fi
+
+  # Check for staged files
+  if $(echo "$INDEX" | command grep '^[MARC][ MD] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
+  elif $(echo "$INDEX" | command grep '^D[ M] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
+  fi
+
+  # Check for modified files
+  if $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
+  fi
+
+  # Check for deleted files
+  if $(echo "$INDEX" | command grep '^[ MARC]D ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
+  fi
+
+  # Check for unmerged files
+  if $(echo "$INDEX" | command grep '^U[DAU] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  elif $(echo "$INDEX" | command grep '^A[UA] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  elif $(echo "$INDEX" | command grep '^D[DU] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  fi
+
+  # Check for stashes
+  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+    git_status="$SPACESHIP_GIT_STATUS_STASHED$git_status"
+  fi
+
+  # Check whether branch is ahead
+  local is_ahead=false
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
+    is_ahead=true
+  fi
+
+  # Check whether branch is behind
+  local is_behind=false
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
+    is_behind=true
+  fi
+
+  # Check wheather branch has diverged
+  if [[ "$is_ahead" == true && "$is_behind" == true ]]; then
+    git_status="$SPACESHIP_GIT_STATUS_DIVERGED$git_status"
+  else
+    [[ "$is_ahead" == true ]] && git_status="$SPACESHIP_GIT_STATUS_AHEAD$git_status"
+    [[ "$is_behind" == true ]] && git_status="$SPACESHIP_GIT_STATUS_BEHIND$git_status"
+  fi
+
+  if [[ -n $git_status ]]; then
+    # Status prefixes are colorized
+    spaceship::section \
+      "$SPACESHIP_GIT_STATUS_COLOR" \
+      "$SPACESHIP_GIT_STATUS_PREFIX$git_status$SPACESHIP_GIT_STATUS_SUFFIX"
+  fi
+}


### PR DESCRIPTION
Adds an actionable Git prompt, proposed in denysdovhan/spaceship-prompt 359. Requires the modular git setup in #1